### PR TITLE
rotate log file daily, not hourly

### DIFF
--- a/src/deb/etc/odn-cas/log4j2.xml
+++ b/src/deb/etc/odn-cas/log4j2.xml
@@ -28,7 +28,7 @@
             <PatternLayout pattern="%d %p [%c] - &lt;%m&gt;%n"/>
         </Console>
         <RollingFile name="file" fileName="/var/log/odn-cas/cas.log" append="true"
-                     filePattern="/var/log/odn-cas/cas-%d{yyyy-MM-dd-HH}-%i.log">
+                     filePattern="/var/log/odn-cas/cas-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="%d %p [%c] - %m%n"/>
             <Policies>
                 <OnStartupTriggeringPolicy />
@@ -38,7 +38,7 @@
             <DefaultRolloverStrategy max="5"/>
         </RollingFile>
         <RollingFile name="perfFileAppender" fileName="/var/log/odn-cas/perfStats.log" append="true"
-                     filePattern="/var/log/odn-cas/perfStats-%d{yyyy-MM-dd-HH}-%i.log">
+                     filePattern="/var/log/odn-cas/perfStats-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="%m%n"/>
             <Policies>
                 <OnStartupTriggeringPolicy />


### PR DESCRIPTION
ODN-CAS is now rotating log files each hour. That is quite too often and not in line with how other ODN components rotate logs.

So, this will set ODN-CAS to rotate the logfiles daily.

Note: Merge will be done by GitFlow automatically on release.
