### PR TITLE
use ${project.version} instead of ${version}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.1.2</version>
 
 	<properties>
-		<debian-package-version>${version}~</debian-package-version>
+		<debian-package-version>${project.version}~</debian-package-version>
 		<debian-package-name>${project.build.directory}/${project.artifactId}-${debian-package-version}_all.deb</debian-package-name>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Maven 3 warns, that:

> [WARNING] Some problems were encountered while building the effective model for sk.eea.edem:odn-cas-overlay:war:1.1.2
> [WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.
> [WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.

This pull request replaces ${version} with ${project.version} .