### PR TITLE
use logrotate only for catalina.out, others are rotated by slf4j

### DIFF
--- a/src/deb/etc/logrotate.d/odn-cas
+++ b/src/deb/etc/logrotate.d/odn-cas
@@ -1,4 +1,4 @@
-/var/log/odn-cas/* {
+/var/log/odn-cas/catalina.out {
   copytruncate
   weekly
   rotate 52


### PR DESCRIPTION
see https://github.com/OpenDataNode/open-data-node/issues/278